### PR TITLE
Fix for error with no items to display

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -34,10 +34,12 @@ Pages::$methods['feed'] = function($pages, $params = array()) {
   $options['link']  = url($options['link']);
 
   // fetch the modification date
-  if($options['datefield'] == 'modified') {
-    $options['modified'] = $items->first()->modified();
-  } else {
-    $options['modified'] = $items->first()->date(null, $options['datefield']);
+  if($items->count()) {
+    if($options['datefield'] == 'modified') {
+      $options['modified'] = $items->first()->modified();
+    } else {
+      $options['modified'] = $items->first()->date(null, $options['datefield']);
+    }
   }
 
   // send the xml header


### PR DESCRIPTION
### Fixes
- When attempting to display a feed with no items, an error is thrown when `date()` or `modified()` is invoked on `null` from `$items->first()`. #1 